### PR TITLE
Add ID to the extension to make it to be packaged on different Linux distributions

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -20,4 +20,10 @@
     },
     "manifest_version": 3,
     "devtools_page": "devtools.html"
+    "browser_specific_settings": {
+      "gecko": {
+        "id": "hacktools@lascc",
+        "strict_min_version": "60.0"
+      }
+    }
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -23,7 +23,7 @@
     "browser_specific_settings": {
       "gecko": {
         "id": "hacktools@lascc",
-        "strict_min_version": "60.0"
+        "strict_min_version": "102.0"
       }
     }
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -19,7 +19,7 @@
         "128": "./src/assets/img/icons/get_started128.png"
     },
     "manifest_version": 3,
-    "devtools_page": "devtools.html"
+    "devtools_page": "devtools.html",
     "browser_specific_settings": {
       "gecko": {
         "id": "hacktools@lascc",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,9 +1,9 @@
 {
-    "name": "Hack-Tools",
-    "version": "0.5.0",
+    "name": "HackTools",
+    "version": "0.5.1",
     "description": "The all in one Red team extension for web pentester",
     "action": {
-        "default_title": "Hack-Tools",
+        "default_title": "HackTools",
         "default_popup": "index.html",
         "default_icon": {
             "16": "./src/assets/img/icons/get_started16.png",


### PR DESCRIPTION
A missing ID prevents the installation of the extension by packaging. By this PR, will be possible to package the extension in order to make it installable at system-level.